### PR TITLE
[Bugfix] Adjust tagger to handle cases with no defined target item

### DIFF
--- a/__tests__/tagInput.test.js
+++ b/__tests__/tagInput.test.js
@@ -40,7 +40,7 @@ describe('tagInput module', () => {
     const inputB = 'get jars';
     const inputC = 'pick up jars';
 
-    const parseObject = { action: 'take', object: 'jars', target: 'jars' };
+    const parseObject = { action: 'take', object: 'jars' };
 
     expect(tagInput(inputA)).toEqual(parseObject);
     expect(tagInput(inputB)).toEqual(parseObject);
@@ -52,7 +52,19 @@ describe('tagInput module', () => {
     const inputB = 'look through the window';
     const inputC = 'inspect the window';
 
-    const parseObject = { action: 'look', object: 'window', target: 'window' };
+    const parseObject = { action: 'look', object: 'window' };
+
+    expect(tagInput(inputA)).toEqual(parseObject);
+    expect(tagInput(inputB)).toEqual(parseObject);
+    expect(tagInput(inputC)).toEqual(parseObject);
+  });
+
+  it('returns parsing object without a target prop, if none is specified', () => {
+    const inputA = 'use book';
+    const inputB = 'Use the book';
+    const inputC = 'open the book';
+
+    const parseObject = { action: 'use', object: 'book' };
 
     expect(tagInput(inputA)).toEqual(parseObject);
     expect(tagInput(inputB)).toEqual(parseObject);

--- a/lib/helpers/gameParser.js
+++ b/lib/helpers/gameParser.js
@@ -8,10 +8,10 @@ const gameParser = async(input) => {
   const { action, object, target, error } = tagInput(input);
 
   // example error
-  if(error) return Promise.reject({
-    msg: error,
-    color: 'red'
-  });
+  // if(error) return Promise.reject({
+  //   msg: error,
+  //   color: 'red'
+  // });
   
   // fix this later - get current user
   const user = await User.findOne();
@@ -33,7 +33,7 @@ const gameParser = async(input) => {
       break;
     }
     default: {
-      Promise.reject({ msg: 'Command not recognized' });
+      Promise.reject({ msg: error, color: 'red' });
     }
   }
 

--- a/lib/lang-processing/tagInput.js
+++ b/lib/lang-processing/tagInput.js
@@ -3,7 +3,7 @@ const lexicon = require('./lexicon');
 module.exports = (input) => {
   // loop through input tokens, return array with data from lexicon
   const tokens = input.split(' ');
-  console.log(tokens);
+  // console.log(tokens);
   
   // create new array of relevant lexical data objects
   const lexData = tokens
@@ -37,14 +37,24 @@ module.exports = (input) => {
     const action = getTokens('ACT')[0];
     
     const items = getTokens('ITM');
-
+    
     if(action && !items[0]) return { error: `You can certainly ${action.token} something, but you'll need to specify a valid item to interact with.` };
-  
-    return {
-      action: action.token,
-      object: items[action.objectPos || 0].token,
-      target: items[action.targetPos || 0].token
+    
+    const obj = {
+      action: action.token
     };
+
+    !items[action.objectPos] ? obj.object = items[0].token : obj.object = items[action.objectPos].token;
+    
+    console.log(obj);
+
+    if(!items[1]) return obj;
+
+    obj.target = items[action.targetPos].token;
+
+    // console.log(obj);
+
+    return obj;
   };
 
   console.log(parserObject());


### PR DESCRIPTION
The tagger output was set up to always return a target of some kind, which didn't work with "use" functions that only triggered correctly without a target value. I tweaked it to replicate the behavior of the original parser, which only registered a target item if one was provided by the user.